### PR TITLE
feat: allow comparison of collections equality - DIA-25971

### DIFF
--- a/pypred/ast.py
+++ b/pypred/ast.py
@@ -32,7 +32,11 @@ class EvalContext(object):
         self.analyze = self._analyze
 
     def resolve_identifier(self, ident):
-        return self.pred.resolve_identifier(self.doc, ident)
+        res = self.pred.resolve_identifier(self.doc, ident)
+        # We always evaluate collections as set
+        if isinstance(res, list):
+            res = set(res)
+        return res
 
 
 def dup(ast):

--- a/tests/integ/preds.txt
+++ b/tests/integ/preds.txt
@@ -25,8 +25,8 @@ thingy is 200 and val is 100 # false
 {"Jack" "Joe" "Jill"} contains name # true
 {400 500} contains status # true
 {"east-db-001" "east-foo-002"} contains server # false
-errors is {"disk full" "cpu load"} #true
-errors == {"disk full" "cpu load"} #true
-{"disk full" "cpu load"} is errors #true
-errors is {"disk full" "cpu load" "other error" } #false
-errors is not {"disk full" "cpu load" "other error" } #true
+errors is {"disk full" "cpu load"} # true
+errors == {"disk full" "cpu load"} # true
+{"disk full" "cpu load"} is errors # true
+errors is {"disk full" "cpu load" "other error"} # false
+errors is not {"disk full" "cpu load" "other error"} # true

--- a/tests/integ/preds.txt
+++ b/tests/integ/preds.txt
@@ -25,3 +25,8 @@ thingy is 200 and val is 100 # false
 {"Jack" "Joe" "Jill"} contains name # true
 {400 500} contains status # true
 {"east-db-001" "east-foo-002"} contains server # false
+errors is {"disk full" "cpu load"} #true
+errors == {"disk full" "cpu load"} #true
+{"disk full" "cpu load"} is errors #true
+errors is {"disk full" "cpu load" "other error" } #false
+errors is not {"disk full" "cpu load" "other error" } #true

--- a/tests/unit/test_ast.py
+++ b/tests/unit/test_ast.py
@@ -295,7 +295,7 @@ class TestAST(object):
         res, ctx = a.analyze(MockPred(), d)
         assert not res
         assert "not in left side" in ctx.failed[0]
-        assert ctx.literals["l"] == []
+        assert ctx.literals["l"] == set()
         assert ctx.literals["r"] == 5
 
     def test_contains_valid(self):
@@ -305,7 +305,7 @@ class TestAST(object):
         d = {"l": [42], "r": 42}
         res, ctx = a.analyze(MockPred(), d)
         assert res
-        assert ctx.literals["l"] == [42]
+        assert ctx.literals["l"] == {42}
         assert ctx.literals["r"] == 42
 
     def test_match_bad_types(self):


### PR DESCRIPTION
## Description

Allow comparison of collections equality with the current equality operators.

## Related JIRA issues

* [DIA-25971]

## Checklist

- [X] Follows [Commit Convention] and [Code Review guidelines] <!-- feat(lang): add German language - DIA-12345 -->
- [X] Relevant labels set 
- [X] Empty sections removed
- [ ] [Draft PR] for WIP
- [X] Requested from and notified to a team


<!-- don't remove -->
[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9
[Draft PR]: https://github.blog/2019-02-14-introducing-draft-pull-requests


[DIA-25971]: https://dialoguemd.atlassian.net/browse/DIA-25971