### PR TITLE
fix: use fullmatch instead of search for MatchOperator

### DIFF
--- a/pypred/ast.py
+++ b/pypred/ast.py
@@ -438,7 +438,7 @@ class MatchOperator(Node):
             return False
 
         right = self.right.eval(ctx)
-        match = right.search(left)
+        match = right.fullmatch(left)
         return match is not None
 
     def failure_info(self, ctx):


### PR DESCRIPTION
## Description

The match operator of pypred uses .search, it should use .fullmatch
.search: look if the regex is matched somewhere in the string
.fullmatch: look the if the whole string matches the regex

this is causing weird behavior when using the botsdk 
`Condition('test matches "[A-Za-z]+"').evaluate({"test": "we./weifj fwifweo"})) ` this should evalute to `False` but it evaluate to `True`


a quick recording showing the issue:
https://user-images.githubusercontent.com/27060431/118173188-3e667f80-b3fb-11eb-84e6-428b00fec118.mov

Is there flows in BM that are relying on the .search behavior, and that could break with this change ?

## Related changes
The validation of slots is not working on: https://github.com/dialoguemd/botfront/pull/17 as it uses the action server, that uses the botsdk, that uses pypred 😳

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [x] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->