### PR TITLE
chore: assign ownership to orphanage [DIA-72288]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+
+*    @dialoguemd/orphanage


### PR DESCRIPTION
## Problem

This service has no owner

## Solution

As agreed in the Platform L10 [here](https://app.asana.com/0/0/1207351125770310/1207952275806009/f), this ervice should be assigned to the Orphanage GitHub group.

## Related

<!-- Relevant: Jira ticket, related PRs, TDs in notion -->

<!-- * #123 -->
<!-- * dialoguemd/scribe#1234  -->
<!-- * [Tech Design](https://www.notion.so/godialogue/854cc91d3e6945dba9be01b9b1f34f8f) -->

* [DIA-72288]

## Validation

<!-- How this PR was validated and why it is safe to merge -->

<!-- 📋 Checklist:
1. Title follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Validation notes added
5. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->


[DIA-72288]: https://dialoguemd.atlassian.net/browse/DIA-72288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ